### PR TITLE
Implemented @dehli's occluded vision algorithm

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -135,6 +135,7 @@
                                   [pjstadig/humane-test-output "0.8.0"]]
 
                    :source-paths ["env/dev/clj"]
+                   :resource-paths ["test-resources"]
 
                    :resource-paths ["tests"]
 

--- a/project.clj
+++ b/project.clj
@@ -135,9 +135,8 @@
                                   [pjstadig/humane-test-output "0.8.0"]]
 
                    :source-paths ["env/dev/clj"]
-                   :resource-paths ["test-resources"]
 
-                   :resource-paths ["tests"]
+                   :resource-paths ["tests" "test-resources"]
 
                    :plugins [[lein-figwheel "0.5.2" :exclusions [org.clojure/core.memoize
                                                                  ring/ring-core

--- a/test-resources/test-arena.edn
+++ b/test-resources/test-arena.edn
@@ -1,0 +1,121 @@
+[[{:type "open", :display "!", :transparent true}
+  {:type "food", :display "+", :transparent false}
+  {:type "open", :display "_", :transparent true}
+  {:type "poison", :display "-", :transparent false}
+  {:type "open", :display "_", :transparent true}
+  {:type "open", :display "_", :transparent true}
+  {:type "food", :display "+", :transparent false}
+  {:type "open", :display "_", :transparent true}
+  {:type "open", :display "_", :transparent true}
+  {:type "open", :display "_", :transparent true}]
+
+ [{:type "open", :display "_", :transparent true}
+  {:type "open", :display "_", :transparent true}
+  {:type "open", :display "_", :transparent true}
+  {:type "block", :display "@", :transparent false}
+  {:type "block", :display "@", :transparent false}
+  {:type "open", :display "_", :transparent true}
+  {:type "open", :display "_", :transparent true}
+  {:type "open", :display "_", :transparent true}
+  {:type "open", :display "_", :transparent true}
+  {:type "open", :display "_", :transparent true}]
+
+ [{:type "open", :display "_", :transparent true}
+  {:type "open", :display "_", :transparent true}
+  {:type "open", :display "_", :transparent true}
+  {:type "open", :display "_", :transparent true}
+  {:type "open", :display "_", :transparent true}
+  {:type "open", :display "_", :transparent true}
+  {:type "open", :display "_", :transparent true}
+  {:type "food", :display "+", :transparent false}
+  {:type "open", :display "_", :transparent true}
+  {:type "open", :display "_", :transparent true}]
+
+ [{:type "food", :display "+", :transparent false}
+  {:type "open", :display "_", :transparent true}
+  {:type "poison", :display "-", :transparent false}
+  {:type "block", :display "@", :transparent false}
+  {:type "open", :display "_", :transparent true}
+  {:type "open", :display "_", :transparent true}
+  {:type "open", :display "_", :transparent true}
+  {:type "open", :display "_", :transparent true}
+  {:type "open", :display "_", :transparent true}
+  {:type "open", :display "_", :transparent true}]
+
+ [{:type "open", :display "_", :transparent true}
+  {:type "open", :display "_", :transparent true}
+  {:type "open", :display "_", :transparent true}
+  {:type "open", :display "_", :transparent true}
+  {:_id "me" :display "B"}
+  {:type "block", :display "@", :transparent false}
+  {:type "open", :display "_", :transparent true}
+  {:type "open", :display "_", :transparent true}
+  {:type "open", :display "_", :transparent true}
+  {:type "food", :display "+", :transparent false}]
+
+ [{:type "open", :display "_", :transparent true}
+  {:type "open", :display "_", :transparent true}
+  {:type "food", :display "+", :transparent false}
+  {:type "open", :display "_", :transparent true}
+  {:type "open", :display "_", :transparent true}
+  {:type "open", :display "_", :transparent true}
+  {:type "open", :display "_", :transparent true}
+  {:type "food", :display "+", :transparent false}
+  {:type "open", :display "_", :transparent true}
+  {:type "open", :display "_", :transparent true}]
+
+ [{:type "open", :display "_", :transparent true}
+  {:type "open", :display "_", :transparent true}
+  {:type "open", :display "_", :transparent true}
+  {:type "open", :display "_", :transparent true}
+  {:type "open", :display "_", :transparent true}
+  {:type "open", :display "_", :transparent true}
+  {:type "block", :display "@", :transparent false}
+  {:type "block", :display "@", :transparent false}
+  {:type "open", :display "_", :transparent true}
+  {:type "open", :display "_", :transparent true}]
+
+ [{:type "open", :display "_", :transparent true}
+  {:type "food", :display "+", :transparent false}
+  {:type "open", :display "_", :transparent true}
+  {:type "open", :display "_", :transparent true}
+  {:type "poison", :display "-", :transparent false}
+  {:type "open", :display "_", :transparent true}
+  {:type "open", :display "_", :transparent true}
+  {:type "open", :display "_", :transparent true}
+  {:type "open", :display "_", :transparent true}
+  {:type "open", :display "_", :transparent true}]
+
+ [{:type "open", :display "_", :transparent true}
+  {:type "open", :display "_", :transparent true}
+  {:type "open", :display "_", :transparent true}
+  {:type "open", :display "_", :transparent true}
+  {:type "food", :display "+", :transparent false}
+  {:type "open", :display "_", :transparent true}
+  {:type "open", :display "_", :transparent true}
+  {:type "open", :display "_", :transparent true}
+  {:type "open", :display "_", :transparent true}
+  {:type "food", :display "+", :transparent false}]
+
+ [{:type "open", :display "_", :transparent true}
+  {:type "open", :display "_", :transparent true}
+  {:type "food", :display "+", :transparent false}
+  {:type "open", :display "_", :transparent true}
+  {:type "open", :display "_", :transparent true}
+  {:type "open", :display "_", :transparent true}
+  {:type "open", :display "_", :transparent true}
+  {:type "open", :display "_", :transparent true}
+  {:type "block", :display "@", :transparent false}
+  {:type "food", :display "+", :transparent false}]
+
+ [{:type "open", :display "_", :transparent true}
+  {:type "open", :display "_", :transparent true}
+  {:type "open", :display "_", :transparent true}
+  {:type "open", :display "_", :transparent true}
+  {:type "food", :display "+", :transparent false}
+  {:type "open", :display "_", :transparent true}
+  {:type "open", :display "_", :transparent true}
+  {:type "open", :display "_", :transparent true}
+  {:type "open", :display "_", :transparent true}
+  {:type "food", :display "+", :transparent false}]]
+:eof


### PR DESCRIPTION
in Clojure

* ref: https://gist.github.com/dehli/b7658fa9e53459376db612ae650310a2
* Also cleaned up pretty-print-arena => pprint-arena
  - Previous version flipped x & y of arena 
* Added executable code in a comment to allow test
  user to see how occluded-arena works.
* occluded-arena assumes that view-dist is equal
  to the count of the x-dimension since it should
  only be passed the limited view arena