### PR TITLE
Feature/arena organization

### DIFF
--- a/src/clj/battlebots/arena/generation.clj
+++ b/src/clj/battlebots/arena/generation.clj
@@ -1,32 +1,24 @@
-(ns battlebots.arena
+(ns battlebots.arena.generation
   (:require [battlebots.constants.arena :refer [arena-key]]
-            [battlebots.utils.arena :refer :all]))
+            [battlebots.arena.utils :refer [get-arena-dimensions update-cell]]))
 
-(defn arena-icon
-  [key]
-  (:display (key arena-key)))
-
-;; ----------------------------------
-;; MAP GENERATION HELPERS
-;; ----------------------------------
-
-(defn get-number-of-items
+(defn- get-number-of-items
   "reutrns the number of items based off of a given frequency and the total number
   of cells in a given arena"
   [frequency arena]
   (* (/ frequency 100) (apply * (get-arena-dimensions arena))))
 
-(defn pos-open
+(defn- pos-open
   "returns true of false depending if a given coodinate in a given arena is open"
   [[x y] arena]
   (= (:open arena-key) (get-in arena [x y])))
 
-(defn generate-random-coords
+(defn- generate-random-coords
   "generates random coordinates from a given dimension set"
   [[x y]]
   [(rand-int x) (rand-int y)])
 
-(defn find-random-open-space
+(defn- find-random-open-space
   "returns the coordinates for a random open space in a given arena"
   [arena]
   (let [arena-dimensions (get-arena-dimensions arena)]
@@ -35,30 +27,26 @@
         dimensions
         (recur (generate-random-coords arena-dimensions))))))
 
-(defn update-cell
-  "set the value of an arena cell to the value provided"
-  [arena [x y] v]
-  (let [[xdim ydim] (get-arena-dimensions arena)]
-    (if (or (>= x xdim) (>= y ydim))
-      arena
-      (assoc-in arena [x y] v))))
-
-(defn replacer
+(defn- replacer
   "replaces an empty cell with a value in a given arena"
   [arena item]
   (update-cell arena (find-random-open-space arena) item))
 
-(defn sprinkle
+(defn- sprinkle
   "sprinkles given items into an arena"
   [amount item arena]
   (reduce replacer arena (repeat amount item)))
 
-(defn place-walls
+(defn- place-walls
   "places walls in an organized structures around the arena"
   [amount arena config]
   (let [wall-symbol (:block arena-key)]
     ;; TODO Update wall generation logic Github issue #10
     arena))
+
+;; ;;;;;;;;;;;;;;;;;;;;;;;;
+;; PLACE ITEMS
+;; ;;;;;;;;;;;;;;;;;;;;;;;;
 
 (defn- border
   "places block walls contiguously along the border of the arena"
@@ -76,64 +64,52 @@
                                      (assoc-in [(dec dimy)] block)))))]
       (vec (sequence xform arena)))
     arena))
-;; ----------------------------------
-;; END MAP GENERATION HELPERS
-;; ----------------------------------
 
-;; ----------------------------------
-;; ITEM DROP
-;; ----------------------------------
-
-;; TODO Update logic for each drop method. Right now we drop everything
-;; randomly, this may not be desirable for all items but works for now.
-
-(defn blocks
+(defn- blocks
   "sprinkle blocks around the arena and return a new arena
   make sure there are no inaccessible areas"
   [frequency config arena]
   (let [amount (get-number-of-items frequency arena)]
     (place-walls amount arena config)))
 
-(defn food
+(defn- food
   "sprinkle food around the arena and return a new arena"
   [frequency config arena]
   (let [amount (get-number-of-items frequency arena)]
     (sprinkle amount (:food arena-key) arena)))
 
-(defn poison
+(defn- poison
   "sprinkle poison around the arena and return a new arena"
   [frequency config arena]
   (let [amount (get-number-of-items frequency arena)]
     (sprinkle amount (:poison arena-key) arena)))
 
-(defn add-players
-  "place players around the arena and return a new arean"
+(defn- players
+  "place players around the arena and returns a new arena"
   [players arena]
   (reduce replacer arena players))
-;; ----------------------------------
-;; END ITEM DROP
-;; ----------------------------------
 
-;; ----------------------------------
-;; ARENA GENERATION
-;; ----------------------------------
+;; ;;;;;;;;;;;;;;;;;;;;;;
+;; END PLACE ITEMS
+;; ;;;;;;;;;;;;;;;;;;;;;;
+
+(defn add-players
+  "Public interface for adding players to an arena"
+  [player-collection arena]
+  (players player-collection arena))
+
+(defn empty-arena
+  "returns an empty arena"
+  [dimx dimy]
+  (vec (repeat dimx (vec (repeat dimy (:open arena-key))))))
 
 (defn new-arena
   "compose all arena building functions to make a fresh new arena"
   [{:keys [dimx dimy food-freq block-freq poison-freq] :as config}]
   (let [arena (empty-arena dimx dimy)]
-    ((apply comp (partial border config)
+    ((apply comp
+            (partial border config)
             (map (fn [item-func item-frequency]
                    (partial item-func item-frequency config))
                  [poison food blocks]
                  [poison-freq food-freq block-freq])) arena)))
-;; ----------------------------------
-;; END ARENA GENERATION
-;; ----------------------------------
-
-(defn test-draw-line
-  [x1 y1 x2 y2]
-  (let [arena (empty-arena (+ 5 (max x1 x2)) (+ 5 (max y1 y2)))
-        line (draw-line x1 y1 x2 y2)
-        res-arena (reduce (fn [a p] (update-cell a p {:display "*"})) arena line)]
-    res-arena))

--- a/src/clj/battlebots/arena/occlusion.clj
+++ b/src/clj/battlebots/arena/occlusion.clj
@@ -1,0 +1,88 @@
+(ns battlebots.arena.occlusion
+  (require [battlebots.constants.arena :refer [arena-key]]))
+
+(def ^:private slopes [[1 0] [-1 0] [0 1] [0 -1]])
+
+(defn- normalize-slope
+  [[x y]]
+  (if (zero? y)
+    [(/ x (Math/abs x)) y]
+    (let [length (Math/sqrt (+ (* x x) (* y y)))]
+      [(/ x length) (/ y length)])))
+
+(defn- corners
+  [[x y]]
+  (let [[nx ny] (normalize-slope [x y])
+        negx (- nx)
+        negy (- ny)]
+    [[nx ny] [negx ny] [nx negy] [negx negy]]))
+
+(defn- angles
+  [view-dist]
+  (concat slopes
+          (mapcat #(corners [% view-dist]) (range 1 (inc view-dist)))
+          (mapcat #(corners [view-dist %]) (range 1 view-dist))))
+
+(defn- blocked-pos?
+  [arena [x y]]
+  (= "block" (get-in arena [x y :type])))
+
+(defn- fog-of-war
+  [arena pos]
+  (if (get-in arena pos)
+    (assoc-in arena pos (:fog arena-key))
+    arena))
+
+(defn- finalize-pos
+  [arena pos]
+  [pos (blocked-pos? arena pos)])
+
+(defn- new-pos
+  [ray-length rxy xy]
+  (int (Math/round (+ rxy (* xy (double ray-length))))))
+
+(defn- parse-pos
+  [arena view-dist ray-length [rx ry] [x y :as ang]]
+  (if (zero? x)
+    (finalize-pos arena [(int rx)
+                         (int (+ ry (* ray-length x)))])
+    (finalize-pos arena [(new-pos ray-length rx x)
+                         (new-pos ray-length ry y)])))
+
+(defn- blocked-pos
+  [arena view-dist player-pos]
+  (:blocked-pos
+   (reduce
+    (fn [bmap ray-length]
+      (reduce
+       (fn [blocked-map ang]
+         (let [ang-blocked? (contains? (:blocked-angs blocked-map) ang)
+               [pos pos-blocked?] (parse-pos arena view-dist ray-length
+                                             player-pos ang)]
+           (-> blocked-map
+               (update-in [:blocked-angs]
+                          #(if pos-blocked?
+                             (conj % ang) %))
+               (update-in [:blocked-pos]
+                          #(if ang-blocked?
+                             (conj % pos) %)))))
+              bmap (angles view-dist)))
+           {:blocked-angs #{}
+            :blocked-pos #{}}
+           (range 1 (inc view-dist)))))
+
+(defn occluded-arena
+  "Only pass the limited arena that the user can see,
+   this fn does not alter the size of the arena passed."
+  [arena player-pos]
+  (let [blocked-pos (blocked-pos arena (count arena) player-pos)]
+    (reduce fog-of-war arena blocked-pos)))
+
+(comment
+  ;; eval (C-x C-e) each line to see the occluded-arena work
+  (require '[clojure.edn :as edn])
+  (require '[clojure.java.io :as io])
+  (require '[battlebots.utils.arena :refer [pprint-arena]])
+  (def t-arena (edn/read-string (slurp "test-resources/test-arena.edn")))
+  (def o-arena (occluded-arena t-arena [4 4]))
+  (pprint-arena o-arena))

--- a/src/clj/battlebots/arena/utils.clj
+++ b/src/clj/battlebots/arena/utils.clj
@@ -1,11 +1,6 @@
-(ns battlebots.utils.arena
+(ns battlebots.arena.utils
   (:require [battlebots.constants.arena :refer [arena-key]]
             [clojure.string :as string]))
-
-(defn empty-arena
-  "returns an empty arena"
-  [dimx dimy]
-  (vec (repeat dimx (vec (repeat dimy (:open arena-key))))))
 
 (defn get-item
   "gets an item based off of given coords"
@@ -18,6 +13,14 @@
   (let [x (count arena)
         y ((comp count first) arena)]
     [x y]))
+
+(defn update-cell
+  "set the value of an arena cell to the value provided"
+  [arena [x y] v]
+  (let [[xdim ydim] (get-arena-dimensions arena)]
+    (if (or (>= x xdim) (>= y ydim))
+      arena
+      (assoc-in arena [x y] v))))
 
 (defn get-arena-row-cell-length
   "Similar to arena/get-arena-dimensions except that it is zero based"
@@ -155,3 +158,11 @@
   (print (string/join "\n"
                       (for [row arena]
                         (string/join " " (map :display row))))))
+(comment
+  (require [battlebots.arena.generation :refer [empty-arena]])
+  (defn test-draw-line
+    [x1 y1 x2 y2]
+    (let [arena (empty-arena (+ 5 (max x1 x2)) (+ 5 (max y1 y2)))
+          line (draw-line x1 y1 x2 y2)
+          res-arena (reduce (fn [a p] (update-cell a p {:display "*"})) arena line)]
+      res-arena)))

--- a/src/clj/battlebots/constants/arena.clj
+++ b/src/clj/battlebots/constants/arena.clj
@@ -14,6 +14,9 @@
                          :transparent false}
                 :poison {:type "poison"
                          :display "-"
+                         :transparent false}
+                :fog    {:type "fog"
+                         :display "?"
                          :transparent false}})
 
 ;; Example Arena Configurations

--- a/src/clj/battlebots/controllers/games.clj
+++ b/src/clj/battlebots/controllers/games.clj
@@ -1,8 +1,8 @@
 (ns battlebots.controllers.games
   (:require [ring.util.response :refer [response]]
             [battlebots.services.mongodb :as db]
+            [battlebots.arena.generation :as generate]
             [battlebots.constants.arena :refer [small-arena large-arena]]
-            [battlebots.arena :as arena]
             [battlebots.game :as game]
             [monger.result :as mr])
   (:import org.bson.types.ObjectId))
@@ -31,7 +31,7 @@
 (defn add-game
   "adds a new game"
   []
-  (let [arena (arena/new-arena large-arena)
+  (let [arena (generate/new-arena large-arena)
         game {:initial-arena arena
               :players [] ;; test-players
               :state "pending"}]
@@ -42,7 +42,7 @@
   ;; TODO implement FSM to handle game state transitions
   [game-id]
   (let [game (db/get-game game-id)
-        initialized-arena (arena/add-players (:players game) (:initial-arena game))
+        initialized-arena (generate/add-players (:players game) (:initial-arena game))
         updated-game (assoc game :initial-arena initialized-arena :state "initialized")
         update (db/update-game game-id updated-game)]
     (if (mr/acknowledged? update)

--- a/src/clj/battlebots/utils/arena.clj
+++ b/src/clj/battlebots/utils/arena.clj
@@ -92,96 +92,6 @@
                   (recur (inc x) (+ y y-step) (+ error (- delta-x delta-y)) (conj res pt))
                   (recur (inc x) y            (- error delta-y) (conj res pt)))))))))))
 
-(def ^:private slopes [[1 0] [-1 0] [0 1] [0 -1]])
-
-(defn- normalize-slope
-  [[x y]]
-  (if (zero? y)
-    [(/ x (Math/abs x)) y]
-    (let [length (Math/sqrt (+ (* x x) (* y y)))]
-      [(/ x length) (/ y length)])))
-
-(defn- corners
-  [[x y]]
-  (let [[nx ny] (normalize-slope [x y])
-        negx (- nx)
-        negy (- ny)]
-    [[nx ny] [negx ny] [nx negy] [negx negy]]))
-
-(defn- angles
-  [view-dist]
-  (concat slopes
-          (mapcat #(corners [% view-dist]) (range 1 (inc view-dist)))
-          (mapcat #(corners [view-dist %]) (range 1 view-dist))))
-
-
-
-
-(defn- blocked-pos?
-  [arena [x y]]
-  (= "block" (get-in arena [x y :type])))
-
-(defn- fog-of-war
-  [arena pos]
-  (if (get-in arena pos)
-    (assoc-in arena pos
-              {:type "fog" :display "?" :transparent false})
-    arena))
-
-(defn- finalize-pos
-  [arena pos]
-  [pos (blocked-pos? arena pos)])
-
-(defn- new-pos
-  [ray-length rxy xy]
-  (int (Math/round (+ rxy (* xy (double ray-length))))))
-
-(defn- parse-pos
-  [arena view-dist ray-length [rx ry] [x y :as ang]]
-  (if (zero? x)
-    (finalize-pos arena [(int rx)
-                         (int (+ ry (* ray-length x)))])
-    (finalize-pos arena [(new-pos ray-length rx x)
-                         (new-pos ray-length ry y)])))
-
-(defn- blocked-pos
-  [arena view-dist player-pos]
-  (:blocked-pos
-   (reduce
-    (fn [bmap ray-length]
-      (reduce
-       (fn [blocked-map ang]
-         (let [ang-blocked? (contains? (:blocked-angs blocked-map) ang)
-               [pos pos-blocked?] (parse-pos arena view-dist ray-length
-                                             player-pos ang)]
-           (-> blocked-map
-               (update-in [:blocked-angs]
-                          #(if pos-blocked?
-                             (conj % ang) %))
-               (update-in [:blocked-pos]
-                          #(if ang-blocked?
-                             (conj % pos) %)))))
-              bmap (angles view-dist)))
-           {:blocked-angs #{}
-            :blocked-pos #{}}
-           (range 1 (inc view-dist)))))
-
-(defn occluded-arena
-  "Only pass the limited arena that the user can see,
-   this fn does not alter the size of the arena passed."
-  [arena player-pos]
-  (let [blocked-pos (blocked-pos arena (count arena) player-pos)]
-    (reduce fog-of-war arena blocked-pos)))
-
-(comment
-  ;; eval (C-x C-e) each line to see the occluded-arena work
-  (require '[clojure.edn :as edn])
-  (require '[clojure.java.io :as io])
-  (def t-arena (edn/read-string (slurp "test-resources/test-arena.edn")))
-  (def o-arena (occluded-arena t-arena [4 4]))
-  (pprint-arena o-arena)
-  )
-
 (defn get-arena-area
   [arena [posx posy] radius]
   (let [[xdim ydim] (get-arena-dimensions arena)
@@ -240,6 +150,7 @@
       (map #(subvec % y1 y2) (subvec arena x1 x2)))))
 
 (defn pprint-arena
+  "Pretty Print for a given arena"
   [arena]
   (print (string/join "\n"
                       (for [row arena]

--- a/tests/battlebots/arena/generation_spec.clj
+++ b/tests/battlebots/arena/generation_spec.clj
@@ -1,0 +1,14 @@
+(ns battlebots.arena.generation_spec
+  (:require [battlebots.arena.generation :refer :all]
+            [battlebots.constants.arena :refer [arena-key]])
+  (:use clojure.test))
+
+(def open-space (:open arena-key))
+(def block-space (:block arena-key))
+(def food-space (:food arena-key))
+(def poison-space (:poison arena-key))
+
+(deftest empty-arena-spec
+  (is (= [[open-space open-space] [open-space open-space]] (empty-arena 2 2)))
+  (is (= [[open-space open-space]] (empty-arena 1 2)))
+  (is (= [[open-space] [open-space]] (empty-arena 2 1))))

--- a/tests/battlebots/arena/utils_spec.clj
+++ b/tests/battlebots/arena/utils_spec.clj
@@ -1,5 +1,5 @@
-(ns battlebots.arena-spec
-  (:require [battlebots.utils.arena :refer :all]
+(ns battlebots.arena.utils_spec
+  (:require [battlebots.arena.utils :refer :all]
             [battlebots.constants.arena :refer [arena-key]])
   (:use clojure.test))
 
@@ -12,11 +12,6 @@
                  [open-space open-space block-space poison-space]
                  [block-space block-space food-space poison-space]
                  [open-space open-space food-space poison-space]])
-
-(deftest empty-arena-spec
-  (is (= [[open-space open-space] [open-space open-space]] (empty-arena 2 2)))
-  (is (= [[open-space open-space]] (empty-arena 1 2)))
-  (is (= [[open-space] [open-space]] (empty-arena 2 1))))
 
 (deftest get-item-spec
   (is (= food-space (get-item [0 2] test-arena)))


### PR DESCRIPTION
This PR includes organizational changes. 

- add `battlebots.arena.occlusion.clj`
- move `battlebots.utils.arena.clj` -> `battlebots.arena.utils.clj`
- add `battlebots.arena.generation.clj`

**generation** is responsible for generating content for an arena (food, poison, walls, players / bots)
**occlusion** is responsible for all occlusion logic
**utils** commonly used public arena functions used for working with an arena object

I refactored all the generation logic into its own namespace and made most methods private. @cch1 This will probably effect where you place your wall generation logic. Let me know if you have any questions about how I organized the files and please share any advice you may have when it comes organization.