### PR TITLE
Feature/apply occlusion logic

### DIFF
--- a/src/clj/battlebots/arena/generation.clj
+++ b/src/clj/battlebots/arena/generation.clj
@@ -101,7 +101,7 @@
 (defn empty-arena
   "returns an empty arena"
   [dimx dimy]
-  (vec (repeat dimx (vec (repeat dimy (:open arena-key))))))
+  (vec (repeat dimy (vec (repeat dimx (:open arena-key))))))
 
 (defn new-arena
   "compose all arena building functions to make a fresh new arena"

--- a/src/clj/battlebots/arena/occlusion.clj
+++ b/src/clj/battlebots/arena/occlusion.clj
@@ -82,7 +82,7 @@
   ;; eval (C-x C-e) each line to see the occluded-arena work
   (require '[clojure.edn :as edn])
   (require '[clojure.java.io :as io])
-  (require '[battlebots.utils.arena :refer [pprint-arena]])
+  (require '[battlebots.arena.utils :refer [pprint-arena]])
   (def t-arena (edn/read-string (slurp "test-resources/test-arena.edn")))
   (def o-arena (occluded-arena t-arena [4 4]))
   (pprint-arena o-arena))

--- a/src/clj/battlebots/arena/partial.clj
+++ b/src/clj/battlebots/arena/partial.clj
@@ -1,0 +1,42 @@
+(ns battlebots.arena.partial
+  (:require [battlebots.arena.utils :as au]))
+
+(comment
+  ;; Uncomment for testing
+)
+(require '[clojure.edn :as edn])
+(require '[clojure.java.io :as io])
+(require '[battlebots.arena.utils :refer [pprint-arena]])
+(def t-arena (edn/read-string (slurp "test-resources/test-arena.edn")))
+
+(defn- caclulate-nradius
+  [[x-dim y-dim] requested-radius]
+  (let [max-radius (int (/ x-dim 2))]
+    (if (or (> (* 2 requested-radius) x-dim)
+            (= requested-radius 0))
+      max-radius
+      requested-radius)))
+
+(defn- calculate-box-coords
+  [origin-x origin-y dim-x dim-y radius]
+  (let [[x1 y1] (au/adjust-coords [origin-x origin-y] 0 [dim-x dim-y] radius)
+        [x2 y2] (au/adjust-coords [origin-x origin-y] 4 [dim-x dim-y] radius)]
+    [x1 y1 x2 y2]))
+
+(defn- slice-arena-vector
+  [arena-vec stop-one stop-two]
+  (if (< stop-one stop-two)
+    (vec (subvec arena-vec stop-one (inc stop-two)))
+    (let [calculated-stop (+ stop-two (count arena-vec))
+          padded-vec (vec (concat arena-vec arena-vec))]
+      (vec (subvec padded-vec stop-one (inc calculated-stop))))))
+
+(defn get-arena-area
+  "returns a partial arena centered on a given coordinate"
+  [arena [pos-x pos-y] radius]
+  (let [[x y] (au/get-arena-dimensions arena)
+        nradius (caclulate-nradius [x y] radius)
+        [x1 y1 x2 y2] (calculate-box-coords pos-x pos-y x y nradius)
+        rows (slice-arena-vector arena y1 y2)
+        area (vec (map #(slice-arena-vector % x1 x2) rows))]
+    area))

--- a/src/clj/battlebots/arena/utils.clj
+++ b/src/clj/battlebots/arena/utils.clj
@@ -10,9 +10,14 @@
 (defn get-arena-dimensions
   "returns the dimensions of a given arena (NOTE: Not 0 based)"
   [arena]
-  (let [x (count arena)
-        y ((comp count first) arena)]
+  (let [x ((comp count first) arena)
+        y (count arena)]
     [x y]))
+
+(defn get-arena-dimensions-zero-idx
+  "Similar to arena/get-arena-dimensions except that it is zero based"
+  [arena]
+  (map dec (get-arena-dimensions arena)))
 
 (defn update-cell
   "set the value of an arena cell to the value provided"
@@ -21,11 +26,6 @@
     (if (or (>= x xdim) (>= y ydim))
       arena
       (assoc-in arena [y x] v))))
-
-(defn get-arena-row-cell-length
-  "Similar to arena/get-arena-dimensions except that it is zero based"
-  [arena]
-  (map dec (get-arena-dimensions arena)))
 
 (defn wrap-coords
   "wraps the coords around to the other side of the arena"
@@ -95,44 +95,21 @@
                   (recur (inc x) (+ y y-step) (+ error (- delta-x delta-y)) (conj res pt))
                   (recur (inc x) y            (- error delta-y) (conj res pt)))))))))))
 
-(defn get-arena-area
-  "returns a partial arena centered on a given coordinate"
-  [arena [posx posy] radius]
-  (let [[xdim ydim] (get-arena-dimensions arena)
-        [xmax ymax] (map dec [xdim ydim])
-        maxradius (int (/ (dec xdim) 2))
-        nradius (if (or (> (inc (* 2 radius)) xdim) (= radius 0))
-                  maxradius
-                  radius)
-        [x1 y1] (adjust-coords [posx posy] 0 [xmax ymax] nradius)
-        [x2 y2] (adjust-coords [posx posy] 4 [xmax ymax] nradius)
-        ;; now take these coords and copy the ranges of the arena vectors
-        ;; swapping as needed
-        columns (if (> x2 x1)
-                  (subvec arena x1 (inc x2))
-                  (vec (concat (subvec arena (inc x1) xdim) (subvec arena 0 (inc x2)))))
-        area (map (fn [col]
-                    (if (> y2 y1)
-                      (subvec col y1 (inc y2))
-                      (vec (concat (subvec col (inc y1) ydim)
-                                   (subvec col 0 (inc y2)))))) columns)]
-    area))
-
 (defn pprint-arena
   "Pretty Print for a given arena"
   [arena]
   (let [[x-len _] (get-arena-dimensions arena)
         x-indices (range x-len)]
-    (println " " (string/join " " (vec x-indices)))
+    (println " " (string/join " " (map #(format "%2d" %) x-indices)))
     (print
      (string/join "\n" (map-indexed (fn [idx row]
                                       (print
-                                       idx
-                                       (string/join " " (map :display row))
+                                       (format "%2d" idx)
+                                       (string/join "  " (map :display row))
                                        "\n")) arena)))))
 
 (comment
-  (require [battlebots.arena.generation :refer [empty-arena]])
+  (require '[battlebots.arena.generation :refer [empty-arena]])
   (defn test-draw-line
     [x1 y1 x2 y2]
     (let [arena (empty-arena (+ 5 (max x1 x2)) (+ 5 (max y1 y2)))

--- a/src/clj/battlebots/arena/utils.clj
+++ b/src/clj/battlebots/arena/utils.clj
@@ -4,8 +4,8 @@
 
 (defn get-item
   "gets an item based off of given coords"
-  [coords arena]
-  (get-in arena coords))
+  [[x y] arena]
+  (get-in arena [y x]))
 
 (defn get-arena-dimensions
   "returns the dimensions of a given arena (NOTE: Not 0 based)"
@@ -20,7 +20,7 @@
   (let [[xdim ydim] (get-arena-dimensions arena)]
     (if (or (>= x xdim) (>= y ydim))
       arena
-      (assoc-in arena [x y] v))))
+      (assoc-in arena [y x] v))))
 
 (defn get-arena-row-cell-length
   "Similar to arena/get-arena-dimensions except that it is zero based"
@@ -44,7 +44,7 @@
             :else c-y)]
     [x y]))
 
-(defn incx [x] (fn [v] (+ x v)))
+(defn- incx [x] (fn [v] (+ x v)))
 
 (defn adjust-coords
   "Returns a new set of coords based off of an applied direction.
@@ -155,9 +155,16 @@
 (defn pprint-arena
   "Pretty Print for a given arena"
   [arena]
-  (print (string/join "\n"
-                      (for [row arena]
-                        (string/join " " (map :display row))))))
+  (let [[x-len _] (get-arena-dimensions arena)
+        x-indices (range x-len)]
+    (println " " (string/join " " (vec x-indices)))
+    (print
+     (string/join "\n" (map-indexed (fn [idx row]
+                                      (print
+                                       idx
+                                       (string/join " " (map :display row))
+                                       "\n")) arena)))))
+
 (comment
   (require [battlebots.arena.generation :refer [empty-arena]])
   (defn test-draw-line

--- a/src/clj/battlebots/arena/utils.clj
+++ b/src/clj/battlebots/arena/utils.clj
@@ -100,7 +100,7 @@
   (let [[xdim ydim] (get-arena-dimensions arena)
         [xmax ymax] (map dec [xdim ydim])
         maxradius (int (/ (dec xdim) 2))
-        nradius (if (> (inc (* 2 radius)) xdim)
+        nradius (if (or (> (inc (* 2 radius)) xdim) (= radius 0))
                   maxradius
                   radius)
         [x1 y1] (adjust-coords [posx posy] 0 [xmax ymax] nradius)
@@ -116,41 +116,6 @@
                       (vec (concat (subvec col (inc y1) ydim)
                                    (subvec col 0 (inc y2)))))) columns)]
     area))
-
-(defn get-wrapped-area-in-range
-  "given an arena, a position, and fov radius return an arena subset within range"
-  [arena [posx posy] radius]
-  ;; find corners
-  (let [[xdim ydim] (get-arena-dimensions arena)
-        [x1 y1] (adjust-coords [posx posy] 0 [xdim ydim] radius)
-        [x2 y2] (adjust-coords [posx posy] 4 [xdim ydim] radius)
-        tpose-arena (apply map vector arena)
-        diameter (* 2 radius)
-        rangex (if (>= (inc diameter) xdim)
-                 xdim
-                 (inc diameter))
-        rangey (if (>= (inc diameter) ydim)
-                 ydim
-                 (inc diameter))
-        ;; if y1 > y2 prepend tail vectors to head
-        arenay (if (> y1 y2) (conj (subvec tpose-arena (inc y1))
-                                   (take y2 tpose-arena)))]
-    (let [dims (get-arena-dimensions arena)
-          x-bound (- (get dims 0) 1)
-          y-bound (- (get dims 1) 1)
-          x1 (if (> radius posx)
-               (- posx (mod radius posx))
-               (- posx radius))
-          x2 (if (> (+ posx radius) x-bound)
-               (+ posx (mod (+ posx radius) x-bound))
-               (+ posx radius))
-          y1 (if (> radius posy)
-               (- posy (mod radius posy))
-               (- posy radius))
-          y2 (if (> (+ posy radius) y-bound)
-               (+ posy (mod (+ posy radius)) y-bound)
-               (+ posy radius))]
-      (map #(subvec % y1 y2) (subvec arena x1 x2)))))
 
 (defn pprint-arena
   "Pretty Print for a given arena"

--- a/src/clj/battlebots/arena/utils.clj
+++ b/src/clj/battlebots/arena/utils.clj
@@ -96,6 +96,7 @@
                   (recur (inc x) y            (- error delta-y) (conj res pt)))))))))))
 
 (defn get-arena-area
+  "returns a partial arena centered on a given coordinate"
   [arena [posx posy] radius]
   (let [[xdim ydim] (get-arena-dimensions arena)
         [xmax ymax] (map dec [xdim ydim])

--- a/src/clj/battlebots/constants/arena.clj
+++ b/src/clj/battlebots/constants/arena.clj
@@ -31,6 +31,7 @@
 
 (def large-arena {:dimx 50
                   :dimy 50
+                  :border {:tunnel false}
                   :food-freq 10
                   :block-freq 10
                   :poison-freq 3})

--- a/src/clj/battlebots/constants/game.clj
+++ b/src/clj/battlebots/constants/game.clj
@@ -3,4 +3,4 @@
 ;; Number of rounds in a chunked segment
 (def segment-length 30)
 ;; Number of rounds in a game
-(def game-length 120)
+(def game-length 100)

--- a/src/clj/battlebots/controllers/games.clj
+++ b/src/clj/battlebots/controllers/games.clj
@@ -7,20 +7,6 @@
             [monger.result :as mr])
   (:import org.bson.types.ObjectId))
 
-;; TODO Remove when done testing
-(def test-players [{:_id 1 :login "AI1"}
-                   {:_id 2 :login "AI2"}
-                   {:_id 3 :login "AI3"}
-                   {:_id 4 :login "AI4"}
-                   {:_id 5 :login "AI5"}
-                   {:_id 6 :login "AI6"}
-                   {:_id 7 :login "AI7"}
-                   {:_id 8 :login "AI8"}
-                   {:_id 9 :login "AI9"}
-                   {:_id 10 :login "AI10"}
-                   {:_id 11 :login "AI11"}
-                   {:_id 12 :login "AI12"}])
-
 (defn get-games
   "returns all games or a specified game"
   ([]
@@ -33,7 +19,7 @@
   []
   (let [arena (generate/new-arena large-arena)
         game {:initial-arena arena
-              :players [] ;; test-players
+              :players []
               :state "pending"}]
     (response (db/add-game game))))
 

--- a/tests/battlebots/arena/generation_spec.clj
+++ b/tests/battlebots/arena/generation_spec.clj
@@ -10,5 +10,5 @@
 
 (deftest empty-arena-spec
   (is (= [[open-space open-space] [open-space open-space]] (empty-arena 2 2)))
-  (is (= [[open-space open-space]] (empty-arena 1 2)))
-  (is (= [[open-space] [open-space]] (empty-arena 2 1))))
+  (is (= [[open-space open-space]] (empty-arena 2 1)))
+  (is (= [[open-space] [open-space]] (empty-arena 1 2))))

--- a/tests/battlebots/arena/partial_spec.clj
+++ b/tests/battlebots/arena/partial_spec.clj
@@ -1,0 +1,25 @@
+(ns battlebots.arena.partial_spec
+  (:require [battlebots.constants.arena :refer [arena-key]]
+            [battlebots.arena.utils :as au]
+            [battlebots.arena.partial :refer :all :as partial])
+  (:use clojure.test))
+
+(def open-space (:open arena-key))
+(def block-space (:block arena-key))
+(def food-space (:food arena-key))
+(def poison-space (:poison arena-key))
+
+(def test-arena [[open-space block-space food-space food-space]
+                 [open-space open-space block-space poison-space]
+                 [block-space block-space food-space poison-space]
+                 [open-space open-space food-space poison-space]])
+
+(deftest get-arena-area-spec
+  (is (= [[open-space block-space food-space]
+          [open-space open-space block-space]
+          [block-space block-space food-space]]
+         (get-arena-area test-arena [1 1] 1)))
+  (is (= [[block-space food-space food-space]
+          [open-space block-space poison-space]
+          [block-space food-space poison-space]]
+         (get-arena-area test-arena [2 1] 1))))

--- a/tests/battlebots/arena/utils_spec.clj
+++ b/tests/battlebots/arena/utils_spec.clj
@@ -20,19 +20,19 @@
   (is (= food-space (get-item [2 3] test-arena))))
 
 (deftest get-arena-dimensions-spec
-  (is (= [3 5] (get-arena-dimensions [[0 0 0 0 0] [0 0 0 0 0] [0 0 0 0 0]])))
-  (is (= [2 2] (get-arena-dimensions [[0 0] [0 0]])))
+  (is (= [5 3] (get-arena-dimensions [[0 0 0 0 0] [0 0 0 0 0] [0 0 0 0 0]])))
+  (is (= [2 5] (get-arena-dimensions [[0 0] [0 0] [0 0] [0 0] [0 0]])))
   (is (= [1 1] (get-arena-dimensions [[0]]))))
+
+(deftest get-arena-dimensions-zero-idx-spec
+  (is (= [4 2] (get-arena-dimensions-zero-idx [[0 0 0 0 0] [0 0 0 0 0] [0 0 0 0 0]])))
+  (is (= [1 4] (get-arena-dimensions-zero-idx [[0 0] [0 0] [0 0] [0 0] [0 0]])))
+  (is (= [0 0] (get-arena-dimensions-zero-idx [[0]]))))
 
 (deftest update-cell-spec
   (is (= food-space (get-item [1 1] (update-cell test-arena [1 1] food-space))))
   (is (= block-space (get-item [1 1] (update-cell test-arena [1 1] block-space))))
   (is (= food-space (get-item [0 1] (update-cell test-arena [0 1] food-space)))))
-
-(deftest get-arena-row-cell-length-spec
-  (is (= [3 3] (get-arena-row-cell-length test-arena)))
-  (is (= [0 5] (get-arena-row-cell-length [[0 0 0 0 0 0]])))
-  (is (= [1 5] (get-arena-row-cell-length [[0 0 0 0 0 0] [0 0 0 0 0 0]]))))
 
 (deftest wrap-coords-spec
   (is (= [0 0] (wrap-coords [0 0] [4 4])))
@@ -91,13 +91,3 @@
 (deftest draw-line-spec
   (is (= [[0 0] [1 1] [2 2] [3 3]] (draw-line 0 0 3 3)) "from (0 0) to (3 3)")
   #_(is (= [[2 2] [2 3] [2 4] [2 5]] (draw-line 2 2 2 5)) "from (2 2) to (2 5)"))
-
-(deftest get-arena-area-spec
-  (is (= [[open-space block-space food-space]
-          [open-space open-space block-space]
-          [block-space block-space food-space]]
-         (get-arena-area test-arena [1 1] 1)))
-  (is (= [[poison-space open-space open-space]
-          [food-space open-space block-space]
-          [poison-space open-space open-space]]
-         (get-arena-area test-arena [0 0] 1))))

--- a/tests/battlebots/arena/utils_spec.clj
+++ b/tests/battlebots/arena/utils_spec.clj
@@ -91,3 +91,13 @@
 (deftest draw-line-spec
   (is (= [[0 0] [1 1] [2 2] [3 3]] (draw-line 0 0 3 3)) "from (0 0) to (3 3)")
   #_(is (= [[2 2] [2 3] [2 4] [2 5]] (draw-line 2 2 2 5)) "from (2 2) to (2 5)"))
+
+(deftest get-arena-area-spec
+  (is (= [[open-space block-space food-space]
+          [open-space open-space block-space]
+          [block-space block-space food-space]]
+         (get-arena-area test-arena [1 1] 1)))
+  (is (= [[poison-space open-space open-space]
+          [food-space open-space block-space]
+          [poison-space open-space open-space]]
+         (get-arena-area test-arena [0 0] 1))))

--- a/tests/battlebots/arena/utils_spec.clj
+++ b/tests/battlebots/arena/utils_spec.clj
@@ -1,5 +1,5 @@
 (ns battlebots.arena.utils_spec
-  (:require [battlebots.arena.utils :refer :all]
+  (:require [battlebots.arena.utils :refer :all :as au]
             [battlebots.constants.arena :refer [arena-key]])
   (:use clojure.test))
 
@@ -14,25 +14,26 @@
                  [open-space open-space food-space poison-space]])
 
 (deftest get-item-spec
-  (is (= food-space (get-item [0 2] test-arena)))
+  (is (= block-space (get-item [0 2] test-arena)))
   (is (= food-space (get-item [2 2] test-arena)))
-  (is (= block-space (get-item [1 2] test-arena))))
+  (is (= poison-space (get-item [3 1] test-arena)))
+  (is (= food-space (get-item [2 3] test-arena))))
 
 (deftest get-arena-dimensions-spec
   (is (= [3 5] (get-arena-dimensions [[0 0 0 0 0] [0 0 0 0 0] [0 0 0 0 0]])))
   (is (= [2 2] (get-arena-dimensions [[0 0] [0 0]])))
   (is (= [1 1] (get-arena-dimensions [[0]]))))
 
+(deftest update-cell-spec
+  (is (= food-space (get-item [1 1] (update-cell test-arena [1 1] food-space))))
+  (is (= block-space (get-item [1 1] (update-cell test-arena [1 1] block-space))))
+  (is (= food-space (get-item [0 1] (update-cell test-arena [0 1] food-space)))))
+
 (deftest get-arena-row-cell-length-spec
   (is (= [3 3] (get-arena-row-cell-length test-arena)))
   (is (= [0 5] (get-arena-row-cell-length [[0 0 0 0 0 0]])))
   (is (= [1 5] (get-arena-row-cell-length [[0 0 0 0 0 0] [0 0 0 0 0 0]]))))
 
-(deftest incx-spec
-  (is (= 6 ((incx 5) 1)))
-  (is (= 4 ((incx 2) 2))))
-
-;; TODO Resolve wrap questions and pass commented tests
 (deftest wrap-coords-spec
   (is (= [0 0] (wrap-coords [0 0] [4 4])))
   (is (= [0 1] (wrap-coords [0 1] [4 4])))
@@ -40,6 +41,10 @@
   (is (= [0 0] (wrap-coords [8 8] [4 4])))
   (is (= [3 1] (wrap-coords [3 9] [4 4])))
   (is (= [1 1] (wrap-coords [5 5] [4 4]))))
+
+(deftest incx-spec
+  (is (= 6 ((#'au/incx 5) 1)))
+  (is (= 4 ((#'au/incx 2) 2))))
 
 ;; Directions
 ;;


### PR DESCRIPTION
@JanxSpirit @thoughtmanifest @dehli 

It appears we were interpreting axis in the arena differently in different parts of our code. 

```clj
(def arena [[00 10 20 30]
            [01 11 21 31]
            [02 12 22 32]
            [03 13 23 33]])
```

the way we are now interpreting coords in the entire app is consistent with;

```clj
(nth arena 0) ;; => [00 10 20 30] => y0
(nth arena 1) ;; => [01 11 21 31] => y1
(nth y1 0)    ;; => 01 => x0
(nth y1 1)    ;; => 11 => x1 
``` 

- update all x y access logic
- update pprint-arena to include axis
- add arena tests