### PR TITLE
Feature/pass state

### DIFF
--- a/src/clj/battlebots/game.clj
+++ b/src/clj/battlebots/game.clj
@@ -85,8 +85,8 @@
   [{:keys [type] :as space}]
   (cond
    (= type "open") {}
-   (= type "food") {:score #(+ % 10)}
-   (= type "poison") {:score #(- % 5)}))
+   (= type "food") {:energy #(+ % 10)}
+   (= type "poison") {:energy #(- % 5)}))
 
 (defn apply-player-update
   "Applies an update to a player object"
@@ -219,9 +219,9 @@
 (defn- initialize-players
   "Preps each player map for the game. This player map is different from
   the one that is contained inside of the arena and will contain private data
-  including scores, decision logic, and saved state."
+  including energy, decision logic, and saved state."
   [players]
-  (map (fn [{:keys [_id bot-repo] :as player}] (merge player {:score 0
+  (map (fn [{:keys [_id bot-repo] :as player}] (merge player {:energy 0
                                                               :bot (get-bot _id bot-repo)
                                                               :saved-state {}})) players))
 

--- a/src/clj/battlebots/game.clj
+++ b/src/clj/battlebots/game.clj
@@ -13,50 +13,50 @@
 
 ;; Modified from
 ;; http://stackoverflow.com/questions/4830900/how-do-i-find-the-index-of-an-item-in-a-vector
-(defn position
+(defn- position
   [pred coll]
   (first (keep-indexed (fn [idx x]
                          (when (pred x)
                            idx))
                        coll)))
 
-(defn total-rounds
+(defn- total-rounds
   "Calculates the total number of rounds that have elapsed"
   [rounds segments]
   (+ (* segments segment-length) rounds))
 
-(defn get-player
+(defn- get-player
   "Grabs a player by id"
   [id collection]
   (first (filter #(= (:_id %) id) collection)))
 
-(defn sanitized-player
+(defn- sanitized-player
   "Sanitizes the full player object returning the partial used on the game map"
   [player]
   (select-keys player [:_id :login]))
 
-(defn save-segment
+(defn- save-segment
   [{:keys [_id players rounds segment-count] :as game-state}]
   (db/save-game-segment {:game-id _id
                          :players (map sanitized-player players)
                          :rounds rounds
                          :segment segment-count}))
 
-(defn randomize-players
+(defn- randomize-players
   "Randomizes player ids"
   [players]
   (shuffle (map #(:_id %) players)))
 
-(defn sanitize-player
+(defn- sanitize-player
   [player]
   (dissoc player :bot :saved-state))
 
-(defn sort-decisions
+(defn- sort-decisions
   "Sorts player decisions based of of a provided execution-order"
   [decisions execution-order]
   (map #(get-player % decisions) execution-order))
 
-(defn get-player-coords
+(defn- get-player-coords
   "Returns a tuple of a given players coords
 
   TODO: There's most likely a better way to accomplish this"
@@ -72,7 +72,7 @@
                            {:row (+ 1 row-number)}))))
                    {:row 0} arena)))
 
-(defn can-occupy-space?
+(defn- can-occupy-space?
   "determins if a bot can occupy a given space"
   [{:keys [type] :as space}]
   (or
@@ -80,7 +80,7 @@
    (= type "food")
    (= type "poison")))
 
-(defn determine-effects
+(defn- determine-effects
   "Determines how player stats should be effected"
   [{:keys [type] :as space}]
   (cond
@@ -88,20 +88,20 @@
    (= type "food") {:energy #(+ % 10)}
    (= type "poison") {:energy #(- % 5)}))
 
-(defn apply-player-update
+(defn- apply-player-update
   "Applies an update to a player object"
   [player update]
   (reduce (fn [player [prop update-fn]]
             (assoc player prop (update-fn (get player prop)))) player update))
 
-(defn modify-player-stats
+(defn- modify-player-stats
   [player-id update players]
   (map (fn [{:keys [_id] :as player}]
          (if (= player-id _id)
            (apply-player-update player update)
            player)) players))
 
-(defn player-occupy-space
+(defn- player-occupy-space
   [coords player-id]
   (fn [{:keys [dirty-arena players] :as game-state}]
      (let [cell-contents (au/get-item coords dirty-arena)
@@ -112,13 +112,13 @@
        (merge game-state {:dirty-arena updated-arena
                           :players updated-players}))))
 
-(defn clear-space
+(defn- clear-space
   [coords]
   (fn [{:keys [dirty-arena] :as game-state}]
      (let [updated-arena (au/update-cell dirty-arena coords (:open arena-key))]
        (merge game-state {:dirty-arena updated-arena}))))
 
-(defn get-bot
+(defn- get-bot
   "Returns the code a bot executes"
   [player-id repo]
   (let [{:keys [bots access-token] :as player} (db/get-player-with-token player-id)
@@ -135,7 +135,7 @@
 ;; the decision map, and the game-state. Once the decision is applied, the decision
 ;; function will return a modifed game-state (:dirty-arena)
 
-(defn move-player
+(defn- move-player
   "Determine if a player can move to the space they have requested, if they can then update
   the board by moving the player and apply any possible consequences of the move to the player."
   [_id {:keys [direction] :as metadata} {:keys [dirty-arena players] :as game-state}]
@@ -149,11 +149,21 @@
                                    (player-occupy-space desired-coords _id)])
       (reduce #(%2 %1) game-state []))))
 
+
+(defn- set-player-state
+  "Player state is player described. This means players can choose to save any key
+  value data they choose. The state will persist and will be sent back to the player
+  each turn. A play can update state as much as they would like"
+  [player-id metadata {:keys [players] :as game-state}]
+  (let [updated-players (map #(if (= (:_id %) player-id)
+                                (assoc % :saved-state metadata)
+                                %) players)]
+    (assoc game-state :players updated-players)))
 ;;
 ;; GAME STATE UPDATE HELPERS
 ;;
 
-(defn process-command
+(defn- process-command
   "Processes a single command for a given player."
   [player-id]
   (fn [game-state command]
@@ -161,9 +171,10 @@
       (cond
        (= cmd "MOVE") (move-player player-id metadata game-state)
        (= cmd "SHOOT") game-state ;; TODO
+       (= cmd "SET_STATE") (set-player-state player-id metadata game-state)
        :else game-state))))
 
-(defn apply-decisions
+(defn- apply-decisions
   "Applies player decision to the current state of the game
 
   TODO: Implement time unit logic
@@ -173,7 +184,7 @@
   (let [{:keys [commands]} decision]
     (reduce (process-command _id) game-state commands)))
 
-(defn resolve-player-decisions
+(defn- resolve-player-decisions
   "Returns a vecor of player decisions based off of the logic provided by
   their bots and an identical clean version of the arena"
   [players clean-arena]
@@ -187,10 +198,10 @@
                        {:arena (occluded-arena
                                 partial-arena
                                 (get-player-coords _id partial-arena))
-                        :state saved-state
-                        :bot_id _id
+                        :saved-state saved-state
+                        :bot-id _id
                         :energy energy
-                        :spawn_bot? false})
+                        :spawn-bot? false})
             :_id _id})) players))
 
 ;;
@@ -200,7 +211,7 @@
 ;; a game-state map
 ;;
 
-(defn resolve-player-turns
+(defn- resolve-player-turns
   "Updates the arena by applying each players movement logic"
   [{:keys [players clean-arena] :as game-state}]
   (let [execution-order (randomize-players players)

--- a/src/cljs/battlebots/components/arena.cljs
+++ b/src/cljs/battlebots/components/arena.cljs
@@ -24,11 +24,11 @@
 
 (defn render-player-stats
   "renders players score & details"
-  [{:keys [login score] :as player}]
+  [{:keys [login energy] :as player}]
   (fn []
     [:li.player-row
      [:p.name login]
-     [:p.score score]]))
+     [:p.score energy]]))
 
 ;; TODO Components are not being updated so we are passing a unique key for each one...
 ;; this is going to be slow. Look into update components without this work around
@@ -44,7 +44,7 @@
 
      [:div.score-board
       [:p.header.name "Name"]
-      [:p.header "Score"]
+      [:p.header "Energy"]
       [:ul.player-stats
        (for [player players]
          ^{:key (rand 10)} [render-player-stats player])]]]))


### PR DESCRIPTION
@JanxSpirit 

Players can now pass state back to their bots

Also include:
- rename of `score` --> `energy`
- update game functions to default to private