### PR TITLE
Fixes issue where nearby blocks on angles displayed as fog

### DIFF
--- a/src/clj/battlebots/constants/arena.clj
+++ b/src/clj/battlebots/constants/arena.clj
@@ -11,10 +11,10 @@
                          :transparent false}
                 :food   {:type "food"
                          :display "+"
-                         :transparent false}
+                         :transparent true}
                 :poison {:type "poison"
                          :display "-"
-                         :transparent false}
+                         :transparent true}
                 :fog    {:type "fog"
                          :display "?"
                          :transparent false}})

--- a/test-resources/test-arena.edn
+++ b/test-resources/test-arena.edn
@@ -1,10 +1,10 @@
 [[{:type "open", :display "!", :transparent true}
   {:type "food", :display "+", :transparent false}
   {:type "open", :display "_", :transparent true}
-  {:type "poison", :display "-", :transparent false}
+  {:type "poison", :display "-", :transparent true}
   {:type "open", :display "_", :transparent true}
   {:type "open", :display "_", :transparent true}
-  {:type "food", :display "+", :transparent false}
+  {:type "food", :display "+", :transparent true}
   {:type "open", :display "_", :transparent true}
   {:type "open", :display "_", :transparent true}
   {:type "open", :display "_", :transparent true}]
@@ -27,13 +27,13 @@
   {:type "open", :display "_", :transparent true}
   {:type "open", :display "_", :transparent true}
   {:type "open", :display "_", :transparent true}
-  {:type "food", :display "+", :transparent false}
+  {:type "food", :display "+", :transparent true}
   {:type "open", :display "_", :transparent true}
   {:type "open", :display "_", :transparent true}]
 
- [{:type "food", :display "+", :transparent false}
+ [{:type "food", :display "+", :transparent true}
   {:type "open", :display "_", :transparent true}
-  {:type "poison", :display "-", :transparent false}
+  {:type "poison", :display "-", :transparent true}
   {:type "block", :display "@", :transparent false}
   {:type "open", :display "_", :transparent true}
   {:type "open", :display "_", :transparent true}
@@ -51,16 +51,16 @@
   {:type "open", :display "_", :transparent true}
   {:type "open", :display "_", :transparent true}
   {:type "open", :display "_", :transparent true}
-  {:type "food", :display "+", :transparent false}]
+  {:type "food", :display "+", :transparent true}]
 
  [{:type "open", :display "_", :transparent true}
   {:type "open", :display "_", :transparent true}
-  {:type "food", :display "+", :transparent false}
+  {:type "food", :display "+", :transparent true}
   {:type "open", :display "_", :transparent true}
   {:type "open", :display "_", :transparent true}
   {:type "open", :display "_", :transparent true}
   {:type "open", :display "_", :transparent true}
-  {:type "food", :display "+", :transparent false}
+  {:type "food", :display "+", :transparent true}
   {:type "open", :display "_", :transparent true}
   {:type "open", :display "_", :transparent true}]
 
@@ -76,10 +76,10 @@
   {:type "open", :display "_", :transparent true}]
 
  [{:type "open", :display "_", :transparent true}
-  {:type "food", :display "+", :transparent false}
+  {:type "food", :display "+", :transparent true}
   {:type "open", :display "_", :transparent true}
   {:type "open", :display "_", :transparent true}
-  {:type "poison", :display "-", :transparent false}
+  {:type "poison", :display "-", :transparent true}
   {:type "open", :display "_", :transparent true}
   {:type "open", :display "_", :transparent true}
   {:type "open", :display "_", :transparent true}
@@ -90,32 +90,32 @@
   {:type "open", :display "_", :transparent true}
   {:type "open", :display "_", :transparent true}
   {:type "open", :display "_", :transparent true}
-  {:type "food", :display "+", :transparent false}
+  {:type "food", :display "+", :transparent true}
   {:type "open", :display "_", :transparent true}
   {:type "open", :display "_", :transparent true}
   {:type "open", :display "_", :transparent true}
   {:type "open", :display "_", :transparent true}
-  {:type "food", :display "+", :transparent false}]
+  {:type "food", :display "+", :transparent true}]
 
  [{:type "open", :display "_", :transparent true}
   {:type "open", :display "_", :transparent true}
-  {:type "food", :display "+", :transparent false}
+  {:type "food", :display "+", :transparent true}
   {:type "open", :display "_", :transparent true}
   {:type "open", :display "_", :transparent true}
   {:type "open", :display "_", :transparent true}
   {:type "open", :display "_", :transparent true}
   {:type "open", :display "_", :transparent true}
   {:type "block", :display "@", :transparent false}
-  {:type "food", :display "+", :transparent false}]
+  {:type "food", :display "+", :transparent true}]
 
  [{:type "open", :display "_", :transparent true}
   {:type "open", :display "_", :transparent true}
   {:type "open", :display "_", :transparent true}
   {:type "open", :display "_", :transparent true}
-  {:type "food", :display "+", :transparent false}
+  {:type "food", :display "+", :transparent true}
   {:type "open", :display "_", :transparent true}
   {:type "open", :display "_", :transparent true}
   {:type "open", :display "_", :transparent true}
   {:type "open", :display "_", :transparent true}
-  {:type "food", :display "+", :transparent false}]]
+  {:type "food", :display "+", :transparent true}]]
 :eof


### PR DESCRIPTION
Fixes #52 
* Also, keyed off of :transparent attribute, not 
  "block" name
* let (angles) call to only calculate once
* As discussed with @oconn, changed transparency
  of food and poison to true
* Altered test-arena to match new transparency rules