### PR TITLE
Fix bug in open position determination

### DIFF
--- a/src/clj/battlebots/arena/generation.clj
+++ b/src/clj/battlebots/arena/generation.clj
@@ -11,7 +11,7 @@
 (defn- pos-open
   "returns true of false depending if a given coodinate in a given arena is open"
   [[x y] arena]
-  (= (:open arena-key) (get-in arena [x y])))
+  (= (:open arena-key) (get-in arena [y x])))
 
 (defn- generate-random-coords
   "generates random coordinates from a given dimension set"

--- a/src/clj/battlebots/arena/generation.clj
+++ b/src/clj/battlebots/arena/generation.clj
@@ -50,18 +50,18 @@
 
 (defn- border
   "places block walls contiguously along the border of the arena"
-  ;; arenas are vectors (seqs?) of columns -not vectors of rows
-  ;; columns are not consistently vectors -they can be seqs
+  ;; arenas are vectors (seqs?) of rows -not vectors of columbs
+  ;; rows are not consistently vectors -they can be seqs
   [{:keys [dimx dimy border]} arena]
   (if border
     (let [block (:block arena-key)
-          vwall (repeat dimy block)
-          xform (map-indexed (fn [x column]
-                               (if (#{0 (dec dimx)} x)
-                                 vwall
-                                 (-> (vec column)
+          hwall (repeat dimx block)
+          xform (map-indexed (fn [y row]
+                               (if (#{0 (dec dimy)} y)
+                                 hwall
+                                 (-> (vec row)
                                      (assoc-in [0] block)
-                                     (assoc-in [(dec dimy)] block)))))]
+                                     (assoc-in [(dec dimx)] block)))))]
       (vec (sequence xform arena)))
     arena))
 

--- a/src/clj/battlebots/arena/utils.clj
+++ b/src/clj/battlebots/arena/utils.clj
@@ -103,10 +103,9 @@
     (println " " (string/join " " (map #(format "%2d" %) x-indices)))
     (print
      (string/join "\n" (map-indexed (fn [idx row]
-                                      (print
-                                       (format "%2d" idx)
-                                       (string/join "  " (map #(or (:display %) "B") row))
-                                       "\n")) arena)))))
+                                      (format "%2d %s" idx
+                                              (string/join "  " (map #(or (:display %) "B") row))))
+                                    arena)))))
 
 (comment
   (require '[battlebots.arena.generation :refer [empty-arena]])


### PR DESCRIPTION
Per David Sison, arena is a sequence of rows (and this matches the 
behavior of other functions such as `update-cell`).  Thus cell contents
are found with something like `(get-in $arena [y x])`.

And fix a bug in pprint-arena while we're at it.