### PR TITLE
Add updated shot reducer logic

### DIFF
--- a/src/clj/battlebots/constants/arena.clj
+++ b/src/clj/battlebots/constants/arena.clj
@@ -23,8 +23,11 @@
                 :shoot  {:type "shoot"
                          :display "!"
                          :transparent true
-                         :volatile true}})
-
+                         ;; TODO Remove when shoot no longer uses this
+                         :volatile true}
+                :steel  {:type "steel"
+                         :display "&"
+                         :transparent false}})
 
 (def move-settings {:can-occupy #{:open
                                   :food

--- a/src/clj/battlebots/game/decisions/move_player.clj
+++ b/src/clj/battlebots/game/decisions/move_player.clj
@@ -17,8 +17,8 @@
   (fn [{:keys [dirty-arena players] :as game-state}]
      (let [cell-contents (au/get-item coords dirty-arena)
            player (gu/get-player player-id players)
-           updated-arena (au/update-cell dirty-arena coords (gu/sanitize-player player))
            player-update (determine-effects cell-contents)
+           updated-arena (au/update-cell dirty-arena coords (gu/sanitize-player player))
            updated-players (gu/modify-player-stats player-id player-update players)]
        (merge game-state {:dirty-arena updated-arena
                           :players updated-players}))))

--- a/src/clj/battlebots/game/decisions/resolve_shot.clj
+++ b/src/clj/battlebots/game/decisions/resolve_shot.clj
@@ -3,41 +3,55 @@
             [battlebots.arena.utils :as au]
             [battlebots.game.utils :as gu]))
 
-(defn- resolve-shot-cell
-  [{:keys [type] :as cell-at-point} energy]
-  (cond
-    (< energy 1) cell-at-point
-    (ac/can-occupy? type ac/shot-settings) (assoc-in (:shoot ac/arena-key)
-                                                     [:md :restore-cell]
-                                                     cell-at-point)
-    (ac/destructible? type ac/shot-settings) (if (> (get cell-at-point :energy) energy)
-                                               (assoc cell-at-point
-                                                 :energy
-                                                 (- energy
-                                                    (get cell-at-point :energy)))
-                                               (:shoot ac/arena-key))))
+(defn- add-shot-metadata
+  [cell]
+  ;; TODO This will change per the metadata discussion
+  ;; Keeping the current implementation for the time being
+  (assoc-in (:shoot ac/arena-key) [:md :restore-cell] cell))
 
-(defn- resolve-shoot-damage
-  [shoot-coords])
+(defn- add-shot-damage
+  "Add damage to cells that contain the energy prop"
+  [damage]
+  (fn [cell]
+    (if (:energy cell)
+      (assoc cell :energy (- (:energy cell) damage))
+      cell)))
+
+(defn resolve-shot-cell
+  [{:keys [type] :as cell-at-point} damage]
+  (reduce (fn [cell update-func]
+            (update-func cell)) cell-at-point [(add-shot-damage damage)
+                                               add-shot-metadata]))
+
+(defn- shot-should-progress?
+  "Returns a boolean indicating if a shot should continue down it's path"
+  [should-progress? cell-at-point energy]
+  (boolean (and should-progress?
+               (> energy 0)
+               (ac/can-occupy? (:type cell-at-point) ac/shot-settings))))
+
+(defn- process-shot
+  "Process a cell that a shot passes through"
+  [{:keys [arena energy should-progress?] :as shoot-state} point]
+  (let [cell-at-point (au/get-item point arena)]
+    (if (shot-should-progress? should-progress? cell-at-point energy)
+      (let [cell-energy (get cell-at-point :energy)
+            reduced-energy (Math/max 0 (- energy (or cell-energy 0)))
+            energy-delta (- energy reduced-energy)
+            updated-cell (resolve-shot-cell cell-at-point energy-delta)]
+        {:arena (au/update-cell arena point updated-cell)
+         :energy reduced-energy
+         :should-progress? true})
+      (assoc shoot-state :should-progress? false))))
 
 (defn resolve-shoot
+  "Main shoot function"
   [player-id
    {:keys [direction energy] :as metadata}
    {:keys [dirty-arena] :as game-state}]
   (let [player-coords (gu/get-player-coords player-id dirty-arena)
         shoot-coords (au/draw-line-from-point dirty-arena player-coords direction 10)
-        new-dirty-arena (:arena
-                         (reduce (fn [{:keys [arena e] :as shoot-state} point]
-                                   (let [cell-at-point (au/get-item point arena)
-                                         cell-energy (get cell-at-point :energy)
-                                         d-key (:display cell-at-point)
-                                         updated-cell (resolve-shot-cell
-                                                       cell-at-point e)
-                                         reduced-e (- e (or cell-energy 0))]
-                                     {:arena (au/update-cell
-                                              arena point
-                                              updated-cell)
-                                      :e reduced-e}))
-                                 {:arena dirty-arena :e energy}
-                                 shoot-coords))]
+        new-dirty-arena (:arena (reduce process-shot {:arena dirty-arena
+                                                      :energy energy
+                                                      :should-progress? true} shoot-coords))]
     (assoc game-state :dirty-arena new-dirty-arena)))

--- a/tests/battlebots/game/decisions/resolve_shot_spec.clj
+++ b/tests/battlebots/game/decisions/resolve_shot_spec.clj
@@ -1,0 +1,20 @@
+(ns battlebots.game.decisions.resolve-shot-spec
+  (:require [battlebots.game.decisions.resolve-shot :refer :all :as resolve-shot]
+            [battlebots.constants.arena :as ac])
+  (:use clojure.test))
+
+(deftest shot-should-progress-spec
+  (is (= false (#'resolve-shot/shot-should-progress? false (:open ac/arena-key) 10))
+      "Returns false when should-progress? prop is false")
+  (is (= false (#'resolve-shot/shot-should-progress? true (:open ac/arena-key) 0))
+      "Returns false when energy is 0")
+  (is (= false (#'resolve-shot/shot-should-progress? true (:open ac/arena-key) -10))
+      "Returns false when energy is less than 0")
+  (is (= false (#'resolve-shot/shot-should-progress? true (:steel ac/arena-key) 10))
+      "Returns false when encountering an cell it cannot pass through")
+  (is (= true (#'resolve-shot/shot-should-progress? true (:open ac/arena-key) 10))
+      "Returns true when all of the above test cases return true"))
+
+(deftest add-shot-damage
+  (is (= 10 (:energy ((#'resolve-shot/add-shot-damage 10) (:block ac/arena-key)))))
+  (is (= 5 (:energy ((#'resolve-shot/add-shot-damage 15) (:block ac/arena-key))))))


### PR DESCRIPTION
@JanxSpirit 

When wiring up the new reducer logic we discussed over L&L, I went to write a few tests and realized that the scope of `resolve-shoot` was pretty large and making testing it a bit difficult. I broke it out a bit for testing purposes, let me know what you think. I did not make any updates to the metadata changes we discussed, but I did leave a few TODO comments in there for refactor. 

Other updated include

- Damage applied to any element that has energy, but only the max amount of energy that said element has.
- Included minimal tests
- Added `steel` element to arena key (mainly for testing shot occupy logic, but I think it would also be cool to have indestructible walls.

TODOs: 

- Replace destroyed elements with open space (right now energy will decrease to 0, but the element will not be removed)
- Write metadata update
- More tests when updates applied