### PR TITLE
Add Simulator Support

### DIFF
--- a/env/dev/clj/battlebots/middleware.clj
+++ b/env/dev/clj/battlebots/middleware.clj
@@ -3,7 +3,7 @@
             [prone.middleware :refer [wrap-exceptions]]
             [buddy.auth.backends :as backends]
             [buddy.auth.middleware :refer [wrap-authentication wrap-authorization]]
-            [ring.middleware.json :refer [wrap-json-response]]
+            [ring.middleware.json :refer [wrap-json-response wrap-json-params]]
             [ring.middleware.transit :refer [wrap-transit-params]]
             [ring.middleware.reload :refer [wrap-reload]]
             [battlebots.services.mongodb :as db]
@@ -30,6 +30,7 @@
 (defn wrap-middleware [handler]
   (-> handler
       (wrap-defaults api-defaults) ;; api-defaults should only be set for api endpoints. TODO refactor out site endpoints
+      wrap-json-params
       wrap-transit-params
       wrap-json-response
       (wrap-authorization backend)

--- a/src/clj/battlebots/controllers/playground.clj
+++ b/src/clj/battlebots/controllers/playground.clj
@@ -1,0 +1,36 @@
+(ns battlebots.controllers.playground
+  (:require [ring.util.response :refer [response]]
+            [battlebots.game.step :refer [process-step]]
+            [battlebots.services.github :refer [get-bot]]
+            [battlebots.game.utils :as gu]
+            [battlebots.game.initializers-finalizers :refer [initialize-new-round
+                                                             update-volatile-positions]]
+            [battlebots.schemas.simulation :refer [is-simulation?]]))
+
+(defn- end-simulation-round
+  "Cleans up a simulated round"
+  [{:keys [rounds dirty-arena players] :as game-state}]
+  (let [formatted-round {:arena dirty-arena
+                         :players (map gu/sanitize-player players)}]
+    (merge game-state {:rounds (conj rounds formatted-round)
+                       :clean-arena (update-volatile-positions dirty-arena)})))
+
+(defn run-simulation
+  "Runs a simulated scenario based off user specified parameters"
+  [{:keys [arena bot saved-state energy steps] :as simulation} {:keys [_id login]}]
+  (is-simulation? simulation)
+  (let [player {:_id _id
+                :login login
+                :energy energy
+                :bot (get-bot _id bot)
+                :saved-state saved-state
+                :rounds []}
+        initial-game-state {:clean-arena arena
+                            :players [player]}]
+    (loop [game-state initial-game-state
+           step-count steps]
+      (if (= step-count 0)
+        (response (select-keys game-state [:rounds]))
+        (recur
+         ((comp end-simulation-round process-step initialize-new-round) game-state)
+         (dec step-count))))))

--- a/src/clj/battlebots/game/game_loop.clj
+++ b/src/clj/battlebots/game/game_loop.clj
@@ -7,8 +7,7 @@
                                                              finalize-game]]
             [battlebots.constants.game :refer [segment-length
                                                game-length]]
-            [battlebots.game.step-operators :refer [resolve-player-turns
-                                                    resolve-ai-turns]]))
+            [battlebots.game.step :refer [process-step]]))
 
 (defn- total-rounds
   "Calculates the total number of rounds that have elapsed"
@@ -16,14 +15,11 @@
   (+ (* num-segments segment-length) num-rounds))
 
 (defn- game-loop
+  "Game loop"
   [initial-game-state]
   (loop [{:keys [rounds segment-count] :as game-state} initial-game-state]
     (if (< (total-rounds (count rounds) segment-count) game-length)
-      (let [updated-game-state (reduce (fn [game-state update-function]
-                                         (update-function game-state))
-                                       (initialize-new-round game-state)
-                                       [resolve-player-turns
-                                        resolve-ai-turns])]
+      (let [updated-game-state (process-step (initialize-new-round game-state))]
         (recur (finalize-round updated-game-state)))
       game-state)))
 

--- a/src/clj/battlebots/game/step.clj
+++ b/src/clj/battlebots/game/step.clj
@@ -1,0 +1,9 @@
+(ns battlebots.game.step
+  (:require [battlebots.game.step-operators :refer [resolve-player-turns
+                                                    resolve-ai-turns]]))
+
+(defn process-step
+  "Calculates a single step / frame"
+  [game-state]
+  (reduce #(%2 %1) game-state [resolve-player-turns
+                               resolve-ai-turns]))

--- a/src/clj/battlebots/router.clj
+++ b/src/clj/battlebots/router.clj
@@ -8,6 +8,7 @@
             [battlebots.middleware :refer [wrap-middleware]]
             [battlebots.controllers.games :as games]
             [battlebots.controllers.players :as players]
+            [battlebots.controllers.playground :as playground]
             [battlebots.controllers.authenication :as auth]
             [battlebots.views.index :refer [index]]
             [battlebots.controllers.socket :as ws]))
@@ -89,6 +90,9 @@
                            {:pattern #"^/api/v1/game.*"
                             :handler authenticated-user}
 
+                           {:pattern #"^/api/v1/playground.*"
+                            :handler authenticated-user}
+
                            {:uris ["/api/v1/player/:player-id{\\w+}/bot"
                                    "/api/v1/player/:player-id{\\w+}/bot/:repo{\\w+}"]
                             :handler is-current-user?}
@@ -131,6 +135,10 @@
           (context "/:player-id" [player-id]
             (GET "/" [] (games/get-players game-id player-id))
             (POST "/" req (games/add-player game-id player-id (:params req)))))))
+
+    (context "/simulator" []
+      (POST "/run" req (playground/run-simulation (:params req)
+                                                             (:identity req))))
 
     (context "/player" []
       (GET "/" []  (players/get-players))

--- a/src/clj/battlebots/schemas/simulation.clj
+++ b/src/clj/battlebots/schemas/simulation.clj
@@ -1,0 +1,14 @@
+(ns battlebots.schemas.simulation
+  (:require [schema.core :as s]))
+
+(s/defschema Simulation
+  "simulation schema"
+  {:arena [[s/Any]]
+   :bot s/Str
+   :energy s/Int
+   :saved-state s/Any
+   :steps s/Int})
+
+(defn is-simulation?
+  [simulation]
+  (s/validate Simulation simulation))


### PR DESCRIPTION
@JanxSpirit @mprichard

I know you both mentioned adding support to test bots, here's the first pass at a simulator 
to help with that. It's just an API endpoint for now, but hopefully we'll be able to add 
client or cli support before the hackathon. Details on usage are documented in this wiki.

https://github.com/willowtreeapps/battlebots/wiki/Battlebots-Simulator

- Add simulator endpoint
- Refactor Step into its own namespace
- Add simulator schema